### PR TITLE
Add BSD-3 LICENSE and cross-links to mageck2 repos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Wei Li
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ See [Usage page](USAGE.md).
 
 ## FAQ 
 
+# Related repositories
+
+* [mageck2](https://github.com/davidliwei/mageck2) — source code and issue tracker
+* [mageck2-demo](https://github.com/davidliwei/mageck2-demo) — runnable example datasets and workflows
+* [mageck2-doc](https://github.com/davidliwei/mageck2-doc) — this documentation
+
+# License
+
+This documentation is released under the [BSD 3-Clause License](LICENSE), the same license as mageck2.
+


### PR DESCRIPTION
Adds a `LICENSE` file (BSD 3-Clause, identical to the [mageck2](https://github.com/davidliwei/mageck2) code repo) and a **Related repositories** + **License** section to the README.

- The repo previously had no license.
- Cross-links the code, doc, and demo repos so the set reads as one maintained project.

No content changes to the documentation itself.