### PR TITLE
Migrate usage, file-format, tutorial, and FAQ docs from the legacy MAGeCK wiki

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,127 @@
+# Frequently asked questions
+
+Migrated and updated from the legacy [MAGeCK Q&A](https://sourceforge.net/p/mageck/wiki/QA/).
+Most MAGeCK answers apply to mageck2; commands below use the `mageck2` executable.
+For more, join the [MAGeCK Google group](https://groups.google.com/g/mageck) or
+open an [issue](https://github.com/davidliwei/mageck2/issues).
+
+## Installation
+
+**Q: After a `--user` install, `mageck2` reports "command not found".**
+
+`pip` installs the `mageck2` and `RRA` programs into the environment's `bin`
+directory, which may not be on your `PATH`. Find it and add it — see the
+[installation troubleshooting section](INSTALL.md#troubleshooting-command-not-found).
+
+**Q: I have several mageck installations and the wrong one runs.**
+
+Use a fresh virtual environment (`python -m venv` or a conda environment) so the
+`mageck2` on your `PATH` and its Python package come from the same place. Check
+which executable is active with `which mageck2`.
+
+## Running mageck2
+
+**Q: How do I handle biological vs. technical replicates?**
+
+Pool **technical** replicates of one sample by joining their FASTQ files with a
+comma in `--fastq` (e.g. `--fastq s1_rep1.fastq,s1_rep2.fastq s2_rep1.fastq,s2_rep2.fastq`).
+Treat **biological** replicates as separate samples so mageck2 can model their
+variance — e.g. `mageck2 test -t treat_r1,treat_r2 -c ctrl_r1,ctrl_r2`.
+
+**Q: Reads have a variable-length prefix before the sgRNA. How do I trim it?**
+
+mageck2 determines the trimming length automatically (`--trim-5 AUTO`, the
+default), even when it varies within a file. You may instead give explicit
+lengths (`--trim-5 7,8`), or trim adapters beforehand with a tool such as
+[cutadapt](https://cutadapt.readthedocs.io/).
+
+**Q: Where are the per-sample statistics of my FASTQ files?**
+
+`count` writes a `*.countsummary.txt` file with, per sample, total reads, mapped
+reads, mapping percentage, zero-count sgRNAs, and the Gini index. The same numbers
+appear in the `*.log` file (see [file formats](FILE_FORMATS.md#count-outputs)).
+
+**Q: How do I judge sample quality?**
+
+As rules of thumb for a good negative-selection sample: mapped reads should be
+well over 60% of total reads, and few sgRNAs (<5%, ideally <1%) should have zero
+counts. Positive-selection screens may legitimately have many zero-count sgRNAs.
+For a fuller treatment of QC metrics see the
+[MAGeCK-VISPR paper](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-015-0843-6).
+
+**Q: mageck2 cannot read my library or control-sgRNA file, though it looks fine.**
+
+This is usually a line-ending problem from editing the file in a spreadsheet
+program on Windows. Re-save it as plain UTF-8 text with Unix line endings (open in
+a plain-text editor and save), then retry.
+
+**Q: `mle` uses more CPU than the `--threads` value I set.**
+
+numpy/scipy (via MKL/OpenBLAS) parallelize matrix operations independently of
+mageck2's own threads. To cap them, set the environment variable before running:
+
+    export OMP_NUM_THREADS=1
+    mageck2 mle ...
+
+**Q: How do I run a paired analysis?**
+
+Add `--paired` to `test`. The samples in `-t` and `-c` must be equal in number and
+in matching order, so replicate *i* of treatment pairs with replicate *i* of
+control:
+
+    mageck2 test -k count.txt -t treatment_r1,treatment_r2 -c control_r1,control_r2 --paired
+
+Paired mode treats the sgRNAs of each pair as independent, effectively doubling the
+sgRNAs per gene. This boosts power when replicates are poorly correlated, but can
+introduce false positives when they are highly correlated — use it selectively.
+
+## Interpreting results
+
+**Q: How do I tell whether the screen worked?**
+
+First check that the sample statistics look healthy (above). Then look at
+well-known genes: negative-selection screens should rank ribosomal genes and
+common essential genes (e.g. MYC) near the top. A good confirmation is to run the
+`pathway` command against MSigDB KEGG gene sets — seeing ribosome, spliceosome,
+proteasome, and cell-cycle pathways enriched is a strong positive sign.
+
+**Q: Very few genes pass my FDR cutoff (e.g. 0.1). Why, and what can I do?**
+
+Libraries with few sgRNAs per gene, large numbers of comparisons, and mageck2's
+deliberately stringent statistics can all make the FDR conservative. To increase
+sensitivity: pre-filter genes you know are irrelevant (very low expression, or <4
+targeting sgRNAs); supply known non-essential controls via `--control-sgrna` /
+`--control-gene` for a better null distribution; and use `--paired` when your
+replicates are paired.
+
+**Q: What does `--control-sgrna` (or `--control-gene`) do?**
+
+It tells mageck2 to build the RRA null distribution from your provided
+non-essential controls instead of assuming every gene is non-essential — usually a
+less conservative, more accurate estimate. With `--norm-method control`, the
+normalization factor is also computed from the controls only. Provide one ID per
+line; see [Tutorial 5](TUTORIAL.md#5-using-negative-control-sgrnas-or-genes) for a
+worked example and caveats.
+
+## Visualization and reports
+
+**Q: How do I generate the analysis report?**
+
+mageck2 emphasizes R Markdown reports. The `count` and `test` commands emit R /
+R Markdown files alongside their results; render them with R (with the relevant
+output files in the same directory), for example:
+
+    Rscript <output_prefix>_summary.R
+
+Keep intermediate files with `--keep-tmp` if a rendering step fails so you can
+inspect or re-run it. (The legacy static PDF report path is being retired in
+mageck2 in favor of R Markdown.)
+
+## Getting more help
+
+- Search or post in the [MAGeCK Google group](https://groups.google.com/g/mageck).
+- Report bugs and request features in the
+  [issue tracker](https://github.com/davidliwei/mageck2/issues) (documentation and
+  demo issues belong in
+  [mageck2-doc](https://github.com/davidliwei/mageck2-doc/issues) /
+  [mageck2-demo](https://github.com/davidliwei/mageck2-demo/issues)).

--- a/FILE_FORMATS.md
+++ b/FILE_FORMATS.md
@@ -1,0 +1,147 @@
+# File formats
+
+This page describes the input and output files used by mageck2. Runnable
+examples of every file below are available in the
+[mageck2-demo](https://github.com/davidliwei/mageck2-demo) repository.
+
+All tabular files are **tab-separated** unless noted otherwise. Column order
+matters: mageck2 identifies the sgRNA and gene columns by position (1st and 2nd),
+not by header name.
+
+---
+
+## Input files
+
+### sgRNA library file (`--list-seq`)
+
+Used by `count` to map reads to sgRNAs. A `csv` or `txt` file with three columns
+and no required header: **sgRNA ID**, **sequence**, **gene**.
+
+    s_10007	TGTTCACAGTATAGTTTGCC	CCNA1
+    s_10008	TTCTCCCTAATTGCTTGCTG	CCNA1
+    s_10027	ACATGTTGCTTCCCCTTGCA	CCNC
+
+Provide an empty file to collect counts for all observed sequences. For
+paired-guide screens, a second library is supplied with `--list-seq-2`.
+
+### Count table (`-k` / `--count-table`)
+
+The primary input to `test`, `mle`, and `plot`, and an alternative input to
+`count`. First row is a header; first two columns are the **sgRNA** and **Gene**,
+followed by one read-count column per sample:
+
+    sgRNA	Gene	HL60.initial	KBM7.initial	HL60.final	KBM7.final
+    A1CF_m52595977	A1CF	213	274	883	175
+    A1CF_m52596017	A1CF	294	412	1554	1891
+
+Sample labels in the header are what you pass to `-t`/`-c` (in `test`) or
+`--include-samples` (in `mle`).
+
+### Design matrix (`-d` / `--design-matrix`) {#design-matrix}
+
+Used by `mle` to describe the experimental design. Tab-separated. The first
+column (`Samples`) lists sample labels matching the count table; the remaining
+columns are the model variables, with a required `baseline` column of all 1s.
+Entries are 0/1:
+
+    Samples	baseline	HL60_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE	KBM7
+    HL60.initial	1	0	0
+    KBM7.initial	1	0	0
+    HL60.final	1	1	0
+    KBM7.final	1	0	1
+
+The matrix may also be given inline as a quoted string, e.g. `-d "1,1;1,0"`
+together with `--include-samples` and `--beta-labels`.
+
+### Control sgRNA / gene list (`--control-sgrna`, `--control-gene`)
+
+A plain text file with one sgRNA ID (or gene ID) per line. Used for
+control-based normalization and for building the RRA null distribution.
+
+### Pathway / gene-set file (`--gmt-file`)
+
+Standard [GMT format](https://software.broadinstitute.org/cancer/software/gsea/wiki/index.php/Data_formats#GMT:_Gene_Matrix_Transposed_file_format_.28.2A.gmt.29):
+one gene set per line — set name, description, then tab-separated gene symbols.
+Used by `pathway` and by `count`'s negative-selection QC.
+
+### CNV files (`--cnv-norm`, `--cnv-est`)
+
+- `--cnv-norm`: a matrix of copy-number values, genes (rows) × cell lines
+  (columns), used to correct CNV-biased scores.
+- `--cnv-est`: a BED file of gene positions, used to *estimate* CNV profiles
+  directly from the screen data.
+
+### sgRNA efficiency file (`--sgrna-efficiency`, `mle` only)
+
+At least two columns: sgRNA ID and a predicted efficiency score. The column
+indices are set with `--sgrna-eff-name-column` / `--sgrna-eff-score-column`
+(0-based).
+
+---
+
+## Output files
+
+All commands write a `[prefix].log` file (`-n`/`--output-prefix` sets the prefix,
+default `sample1`).
+
+### `count` outputs
+
+- **`[prefix].count.txt`** — raw count table (same layout as the count-table
+  input above): `sgRNA`, `Gene`, then one column per sample.
+- **`[prefix].count_normalized.txt`** — normalized counts, same layout.
+- **`[prefix].countsummary.txt`** — per-sample QC summary, one row per input
+  file. Columns:
+
+  | Column | Meaning |
+  |---|---|
+  | `File`, `Label` | input file and sample label |
+  | `Reads`, `Mapped`, `Percentage` | total reads, mapped reads, mapping rate |
+  | `TotalsgRNAs`, `Zerocounts` | sgRNAs in the library, sgRNAs with zero reads |
+  | `GiniIndex` | evenness of sgRNA read distribution |
+  | `NegSelQC*` | negative-selection QC score, p-value, permutation p-value/FDR, and gene count (present when `--day0-label` is used) |
+
+### `test` (RRA) outputs
+
+- **`[prefix].gene_summary.txt`** — gene-level results, with parallel
+  negative- and positive-selection columns:
+
+  | Column | Meaning |
+  |---|---|
+  | `id`, `num` | gene ID, number of sgRNAs |
+  | `neg\|score`, `neg\|p-value`, `neg\|fdr`, `neg\|rank` | negative-selection RRA score, p-value, FDR, rank |
+  | `neg\|goodsgrna`, `neg\|lfc` | # sgRNAs ahead of the alpha cutoff, gene log2 fold change |
+  | `pos\|score` … `pos\|lfc` | the same set of columns for positive selection |
+
+- **`[prefix].sgrna_summary.txt`** — sgRNA-level results. Columns include
+  `sgrna`, `Gene`, `control_count`, `treatment_count`, `control_mean`,
+  `treat_mean`, `LFC`, `control_var`, `adj_var`, `score`, `p.low`, `p.high`,
+  `p.twosided`, `FDR`, and `high_in_treatment`.
+
+- **`[prefix].normalized.txt`** — normalized counts (only with
+  `--normcounts-to-file`).
+
+### `mle` outputs
+
+- **`[prefix].gene_summary.txt`** — one block of columns per condition (variable)
+  in the design matrix: `Gene`, `sgRNA`, then for each condition
+  `<condition>|beta`, `|z`, `|p-value`, `|fdr`, `|wald-p-value`, `|wald-fdr`. The
+  **beta score** is the estimated selection effect (negative = depleted /
+  essential, positive = enriched).
+- **`[prefix].sgrna_summary.txt`** — `Gene`, `sgRNA`, `eff` (estimated sgRNA
+  efficiency).
+
+### `pathway` outputs
+
+A pathway/gene-set enrichment summary (`[prefix].pathway_summary.txt`) reporting,
+for each gene set, its enrichment statistic, p-value, and FDR in the tested
+direction(s). The exact columns depend on `--method` (`gsea` or `rra`).
+
+### `plot` outputs
+
+Per-gene graphics (and an accompanying report) for the genes given in `--genes`.
+
+---
+
+See [USAGE.md](USAGE.md) for the command that produces each file, and the
+[mageck2-demo](https://github.com/davidliwei/mageck2-demo) repository for
+complete, runnable examples.

--- a/FILE_FORMATS.md
+++ b/FILE_FORMATS.md
@@ -66,8 +66,15 @@ Used by `pathway` and by `count`'s negative-selection QC.
 
 ### CNV files (`--cnv-norm`, `--cnv-est`)
 
-- `--cnv-norm`: a matrix of copy-number values, genes (rows) × cell lines
-  (columns), used to correct CNV-biased scores.
+- `--cnv-norm`: a tab-separated matrix of copy-number values, one gene per row
+  and one cell line per column, used to correct CNV-biased scores. The first
+  column header **must** be literally `SYMBOL` (mageck2 looks up gene ids by that
+  name); the remaining headers are cell-line names, matched to `--cell-line` (or,
+  for `mle`, to the design-matrix condition labels):
+
+      SYMBOL	HL60_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE	KBM7
+      A1BG	0.1105	0.0433
+      NAT2	0.0104	-0.2011
 - `--cnv-est`: a BED file of gene positions, used to *estimate* CNV profiles
   directly from the screen data.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ See [Usage page](USAGE.md).
 
 ## File formats
 
-## FAQ 
+See the [file formats page](FILE_FORMATS.md) for the input and output file
+specifications.
+
+## FAQ
+
+Frequently asked questions are being migrated from the legacy MAGeCK wiki. In the
+meantime, see the [MAGeCK Q&A on SourceForge](https://sourceforge.net/p/mageck/wiki/QA/)
+and the [MAGeCK Google group](https://groups.google.com/g/mageck). Most MAGeCK
+answers apply to mageck2.
 
 # Related repositories
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ mageck2 is part of the softwares and databases for functional genetic screens, w
 
 See [installation page](INSTALL.md) for more details.
 
-## Demo
+## Tutorials and demos
 
-We provide a set of running examples for mageck2. See [mageck2-demo](https://github.com/davidliwei/mageck2-demo) for more details.
+See the [tutorials](TUTORIAL.md) for step-by-step walkthroughs, and
+[mageck2-demo](https://github.com/davidliwei/mageck2-demo) for the runnable
+example datasets and scripts.
 
 ## Usage
 
@@ -52,10 +54,8 @@ specifications.
 
 ## FAQ
 
-Frequently asked questions are being migrated from the legacy MAGeCK wiki. In the
-meantime, see the [MAGeCK Q&A on SourceForge](https://sourceforge.net/p/mageck/wiki/QA/)
-and the [MAGeCK Google group](https://groups.google.com/g/mageck). Most MAGeCK
-answers apply to mageck2.
+See the [FAQ page](FAQ.md) for installation, usage, results-interpretation, and
+visualization questions.
 
 # Related repositories
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,174 @@
+# Tutorials
+
+These tutorials walk through common mageck2 workflows. Every example corresponds
+to a folder in the [mageck2-demo](https://github.com/davidliwei/mageck2-demo)
+repository that contains the input data and a `run.sh` script — clone that repo
+and run the commands below from inside the matching folder.
+
+**Prerequisite:** install mageck2 first (see [installation](INSTALL.md)). For the
+input/output file layouts referenced here, see [file formats](FILE_FORMATS.md);
+for the full option reference, see [usage](USAGE.md).
+
+---
+
+## 1. RRA analysis from a read count table
+
+*(demo folder: `demo1_rra_from_count_table`)*
+
+The simplest workflow: given a count table, compare treatment vs. control samples
+and rank sgRNAs and genes with RRA. `sample.txt` has a header line
+(`sgRNA  Gene  HL60.initial  KBM7.initial  HL60.final  KBM7.final`) and one row per
+sgRNA.
+
+    mageck2 test -k sample.txt -t HL60.final,KBM7.final -c HL60.initial,KBM7.initial -n demo
+
+Samples may also be given by index (0-based), so the following is equivalent:
+
+    mageck2 test -k sample.txt -t 2,3 -c 0,1 -n demo
+
+This produces `demo.gene_summary.txt`, `demo.sgrna_summary.txt`, and `demo.log`.
+
+## 2. Starting from raw FASTQ files
+
+*(demo folder: `demo2_run_mageck_from_fastq`)*
+
+If you start from sequencing reads, first build a count table with `count`
+(supplying an sgRNA library file), then run `test`:
+
+    # 1. count reads against the library
+    mageck2 count -l library.txt -n demo --sample-label L1,CTRL --fastq test1.fastq test2.fastq
+
+    # 2. statistical test on the resulting count table
+    mageck2 test -k demo.count.txt -t L1 -c CTRL -n demo
+
+`count` also writes a `demo.countsummary.txt` QC file summarizing mapping rate,
+zero-count sgRNAs, and the Gini index per sample.
+
+> The old all-in-one `run` command has been discontinued; run `count` then `test`.
+
+## 3. Multi-condition analysis with MAGeCK MLE
+
+*(demo folder: `demo3_mle_with_cnv_correction`)*
+
+The MLE module estimates gene **beta scores** (selection effects) across arbitrary
+experimental designs, described by a design matrix. `designmat.txt` is
+tab-separated, with a `Samples` column matching the count table, a required
+`baseline` column of 1s, and one column per condition:
+
+    Samples         baseline    HL60_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE    KBM7
+    HL60.initial    1           0                                          0
+    KBM7.initial    1           0                                          0
+    HL60.final      1           1                                          0
+    KBM7.final      1           0                                          1
+
+Run MLE with:
+
+    mageck2 mle -k leukemia.new.csv -d designmat.txt -n beta_leukemia --permutation-round 2
+
+This produces `beta_leukemia.gene_summary.txt` (one beta/z/p-value/FDR block per
+condition) and `beta_leukemia.sgrna_summary.txt`.
+
+## 4. Correcting copy-number variation (CNV) effects
+
+*(demo folders: `demo4_rra_with_cnv_correction`, `demo3_mle_with_cnv_correction`)*
+
+Amplified regions can produce false positives in essentiality screens. Supply a
+CNV matrix with `--cnv-norm` to correct for this. The matrix is tab-separated with
+a `SYMBOL` gene column and one column of (log2) copy-number values per cell line:
+
+    SYMBOL    HL60_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE
+    A1BG      0.1105
+    NAT2      0.0104
+
+For **RRA**, name the cell line to use with `--cell-line`:
+
+    mageck2 test -k sample.txt -t HL60.final,KBM7.final -c HL60.initial,KBM7.initial \
+        -n demo4 --cnv-norm cnv_data.txt --cell-line HL60_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE
+
+For **MLE**, mageck2 matches the design-matrix condition labels to the CNV columns
+automatically; or override with `--cell-line`:
+
+    # auto-match design labels to CNV columns
+    mageck2 mle -k leukemia.new.csv -d designmat.txt -n beta_leukemia --cnv-norm cnv_data.txt --permutation-round 2
+
+    # or force a specific cell line
+    mageck2 mle -k leukemia.new.csv -d designmat.txt -n beta_leukemia_hl60 --cnv-norm cnv_data.txt \
+        --permutation-round 2 --cell-line HL60_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE
+
+If you do not have a measured CNV profile, `--cnv-est` can estimate one from the
+screen data given a BED file of gene positions.
+
+## 5. Using negative-control sgRNAs or genes
+
+*(demo folder: `demo5_use_control_guides`)*
+
+By default mageck2 builds the RRA null distribution assuming all genes are
+non-essential, which can be over-conservative. If you have known non-essential
+controls, provide them to improve p-value estimation and (with
+`--norm-method control`) normalization. Control files list one ID per line
+(`control_sgrna.txt` = sgRNA IDs, `control_gene.txt` = gene IDs).
+
+    # control sgRNAs
+    mageck2 test -k sample.txt -t HL60.final,KBM7.final -c HL60.initial,KBM7.initial \
+        -n demo_ctrlsg --norm-method control --control-sgrna control_sgrna.txt
+
+    # or control genes
+    mageck2 test -k sample.txt -t HL60.final,KBM7.final -c HL60.initial,KBM7.initial \
+        -n demo_ctrlgene --norm-method control --control-gene control_gene.txt
+
+The same `--control-sgrna` / `--control-gene` options work with `mle`. Notes:
+
+- Use enough control guides (>100 recommended) for a reliable estimate.
+- Non-targeting controls can inflate false positives in growth screens
+  ([Morgens et al. 2017](https://www.nature.com/articles/ncomms15178)); the
+  [MAGeCKFlute](https://www.nature.com/articles/s41596-018-0113-7) non-essential
+  gene list is a good source of controls.
+
+## 6. Counting screens with UMIs
+
+*(demo folder: `demo6_countumi`)*
+
+For screens with unique molecular identifiers (UMIs), add `--umi auto` to `count`;
+mageck2 locates the UMI region automatically:
+
+    mageck2 count -l ibar_library.txt --umi auto -n count/ibar_hela \
+        --sample-label tcb_r1,tcb_r2,ref_r1,ref_r2 \
+        --fastq fastq/SRR7975605_1.fastq.gz fastq/SRR7975606_1.fastq.gz \
+                fastq/SRR7975595_1.fastq.gz fastq/SRR7975596_1.fastq.gz
+
+Besides the usual count table, this writes a `*.umi_count.txt` file whose rows are
+`sgRNA+UMI`, `sgRNA`, then per-sample counts. If you know the UMI position, set it
+explicitly with `--umi-start/--umi-end` (or `--umi-start-2/--umi-end-2` for read 2)
+instead of `auto`.
+
+## 7. Counting paired-guide (dual-sgRNA) screens
+
+*(demo folder: `demo7_count_paired_guide`)*
+
+For vectors carrying two guides, provide the second library with `--list-seq-2`
+and `--pairguide auto`:
+
+    mageck2 count -l lib/Cpf1_lib.txt -n count/pg_test \
+        --sample-label HAP1_Dual,HAP1_Dual_Torin1 \
+        --pairguide auto --reverse-complement --list-seq-2 lib/Cas9_lib.txt \
+        --fastq   fastq/SRR10969645_1.fastq.gz fastq/SRR10969652_1.fastq.gz \
+        --fastq-2 fastq/SRR10969645_2.fastq.gz fastq/SRR10969652_2.fastq.gz
+
+This writes a `*.pg_count.txt` file whose rows are the two concatenated sgRNA IDs
+and the two concatenated gene names, followed by per-sample counts. Use
+`--reverse-complement` / `--reverse-complement-2` if a guide library is stored on
+the opposite strand, and `--pg-pair-only <file>` to restrict output to a defined
+list of allowed guide pairs.
+
+---
+
+## Advanced notes
+
+- **Mismatch-tolerant mapping.** mageck2 `count` accepts SAM/BAM files in place of
+  FASTQ, so you can map reads with an external aligner (e.g. Bowtie2) to allow
+  mismatches and pass the alignments to `count`.
+- **sgRNA efficiency in MLE.** Supply predicted per-sgRNA efficiencies to `mle`
+  with `--sgrna-efficiency` (see [usage](USAGE.md#mle)) to weight guides by their
+  expected activity.
+
+See the [FAQ](README.md#faq) for troubleshooting and interpretation guidance.

--- a/USAGE.md
+++ b/USAGE.md
@@ -265,3 +265,400 @@ Only report paired-guides whose combination is listed
                         this file should has the format "sgid_1 sgid_2", where
                         sgid_1 and sgid_2 are sgRNA IDs from --list-seq and
                         --list-seq-2, respectively.
+
+
+## test
+
+Given a count table (from the `count` command or your own), perform sgRNA- and
+gene-level ranking using the Robust Rank Aggregation (RRA) algorithm, comparing
+treatment vs. control samples. Outputs `[prefix].gene_summary.txt` and
+`[prefix].sgrna_summary.txt` (see [file formats](FILE_FORMATS.md)).
+
+### usage:
+
+    mageck2 test [-h] -k COUNT_TABLE (-t TREATMENT_ID | --day0-label DAY0_LABEL)
+                    [-c CONTROL_ID] [--paired]
+                    [--norm-method {none,median,total,control}]
+                    [--gene-test-fdr-threshold GENE_TEST_FDR_THRESHOLD]
+                    [--adjust-method {fdr,holm,pounds}]
+                    [--variance-estimation-samples VARIANCE_ESTIMATION_SAMPLES]
+                    [--sort-criteria {neg,pos}]
+                    [--remove-zero {none,control,treatment,both,any}]
+                    [--remove-zero-threshold REMOVE_ZERO_THRESHOLD]
+                    [--pdf-report]
+                    [--gene-lfc-method {median,alphamedian,mean,alphamean,secondbest}]
+                    [-n OUTPUT_PREFIX]
+                    [--control-sgrna CONTROL_SGRNA | --control-gene CONTROL_GENE]
+                    [--normcounts-to-file] [--skip-gene SKIP_GENE] [--keep-tmp]
+                    [--additional-rra-parameters ADDITIONAL_RRA_PARAMETERS]
+                    [--cnv-norm CNV_NORM] [--cell-line CELL_LINE] [--cnv-est CNV_EST]
+
+### Required arguments:
+
+*  -k COUNT_TABLE, --count-table COUNT_TABLE
+
+A tab-separated count table. Each line should include the sgRNA name (1st column), gene name (2nd column) and read counts in each sample.
+
+One of the following (mutually exclusive) is required to define the treatment:
+
+*  -t TREATMENT_ID, --treatment-id TREATMENT_ID
+
+Sample label(s) or index(es) (0 as the first sample) in the count table used as treatment experiments, separated by comma (,). Labels must match the first line of the count table (e.g. "HL60.final,KBM7.final"); indexes such as "0,2" select the 1st and 3rd samples.
+
+*  --day0-label DAY0_LABEL
+
+Specify the label for the control sample (usually day 0 or plasmid). Every other sample is treated as a treatment condition and compared with the control.
+
+### Optional general arguments:
+
+*  -c CONTROL_ID, --control-id CONTROL_ID
+
+Control sample label(s) or index(es), separated by comma (,). Default: all samples not listed as treatment.
+
+*  --paired
+
+Paired-sample comparison. The number of samples in `-t` and `-c` must match and be in the same order (e.g. "-t treatment_r1,treatment_r2 -c control_r1,control_r2").
+
+*  --norm-method {none,median,total,control}
+
+Normalization method: "none", "median" (default), "total" (by total read counts), or "control" (by control sgRNAs from `--control-sgrna`).
+
+*  --gene-test-fdr-threshold GENE_TEST_FDR_THRESHOLD
+
+p-value threshold determining the alpha value of RRA in the gene test (RRA `-p`). Default 0.25.
+
+*  --adjust-method {fdr,holm,pounds}
+
+sgRNA-level p-value adjustment: false discovery rate (fdr, default), Holm's method (holm), or Pounds's method (pounds).
+
+*  --variance-estimation-samples VARIANCE_ESTIMATION_SAMPLES
+
+Sample label(s)/index(es) for estimating variances, separated by comma (,).
+
+*  --sort-criteria {neg,pos}
+
+Sort by negative selection (neg, default) or positive selection (pos).
+
+*  --remove-zero {none,control,treatment,both,any}
+
+Remove sgRNAs whose mean value is zero in the given samples. Default: both.
+
+*  --remove-zero-threshold REMOVE_ZERO_THRESHOLD
+
+Normalized-count threshold below which an sgRNA is considered zero for `--remove-zero`. Default 0.
+
+*  --pdf-report
+
+Generate a PDF report of the analysis.
+
+*  --gene-lfc-method {median,alphamedian,mean,alphamean,secondbest}
+
+Method to compute gene log2 fold change from sgRNA LFCs: median/mean of all sgRNAs, median/mean of sgRNAs ranked ahead of the RRA alpha cutoff (alphamedian/alphamean), or the second-strongest sgRNA (secondbest). Default median.
+
+### Optional arguments for input and output:
+
+*  -n OUTPUT_PREFIX, --output-prefix OUTPUT_PREFIX
+
+Prefix of the output file(s). Default sample1.
+
+*  --control-sgrna CONTROL_SGRNA
+
+A list of control sgRNAs for normalization and for generating the RRA null distribution.
+
+*  --control-gene CONTROL_GENE
+
+A list of genes whose sgRNAs are used as control sgRNAs (mutually exclusive with `--control-sgrna`).
+
+*  --normcounts-to-file
+
+Write normalized read counts to `[output-prefix].normalized.txt`.
+
+*  --skip-gene SKIP_GENE
+
+Skip a gene in the report (repeatable). By default "NA"/"na" are skipped.
+
+*  --keep-tmp
+
+Keep intermediate files.
+
+*  --additional-rra-parameters ADDITIONAL_RRA_PARAMETERS
+
+Extra arguments appended to the RRA command line.
+
+### Optional arguments for CNV correction:
+
+*  --cnv-norm CNV_NORM
+
+A matrix of copy-number-variation data across cell lines, used to correct CNV-biased sgRNA scores before gene ranking.
+
+*  --cell-line CELL_LINE
+
+The cell line used for CNV normalization; must match a column name in `--cnv-norm`.
+
+*  --cnv-est CNV_EST
+
+Estimate CNV profiles from the screening data. Requires a BED file of gene positions.
+
+
+## mle
+
+Perform maximum-likelihood estimation (MLE) of gene essentiality (beta scores)
+under a user-supplied experimental design matrix. Supports complex designs
+(time-series, multiple conditions, drug treatments). Outputs
+`[prefix].gene_summary.txt` (beta scores) and `[prefix].sgrna_summary.txt`
+(see [file formats](FILE_FORMATS.md)).
+
+### usage:
+
+    mageck2 mle [-h] -k COUNT_TABLE (-d DESIGN_MATRIX | --day0-label DAY0_LABEL)
+                   [-n OUTPUT_PREFIX] [-i INCLUDE_SAMPLES] [-b BETA_LABELS]
+                   [--control-sgrna CONTROL_SGRNA | --control-gene CONTROL_GENE]
+                   [--cnv-norm CNV_NORM] [--cell-line CELL_LINE] [--cnv-est CNV_EST]
+                   [--debug] [--debug-gene DEBUG_GENE]
+                   [--norm-method {none,median,total,control}]
+                   [--genes-varmodeling GENES_VARMODELING]
+                   [--permutation-round PERMUTATION_ROUND]
+                   [--no-permutation-by-group]
+                   [--max-sgrnapergene-permutation MAX_SGRNAPERGENE_PERMUTATION]
+                   [--remove-outliers] [--threads THREADS]
+                   [--adjust-method {fdr,holm,pounds}]
+                   [--sgrna-efficiency SGRNA_EFFICIENCY]
+                   [--sgrna-eff-name-column SGRNA_EFF_NAME_COLUMN]
+                   [--sgrna-eff-score-column SGRNA_EFF_SCORE_COLUMN]
+                   [--update-efficiency] [--bayes] [-p] [-w PPI_WEIGHTING]
+                   [-e NEGATIVE_CONTROL]
+
+### Required arguments:
+
+*  -k COUNT_TABLE, --count-table COUNT_TABLE
+
+A tab-separated count table. Each line should include the sgRNA name (1st column), target gene (2nd column) and read counts in each sample.
+
+One of the following (mutually exclusive) is required:
+
+*  -d DESIGN_MATRIX, --design-matrix DESIGN_MATRIX
+
+A design matrix, given as a file name or a quoted string (e.g. "1,1;1,0"). Rows must match the order of samples in the count table (or the order given by `--include-samples`). See [file formats](FILE_FORMATS.md#design-matrix) for the file layout.
+
+*  --day0-label DAY0_LABEL
+
+Specify the label for the control sample (usually day 0 or plasmid); a corresponding design matrix is generated automatically, treating every other sample as a condition.
+
+### Optional arguments for input and output:
+
+*  -n OUTPUT_PREFIX, --output-prefix OUTPUT_PREFIX
+
+Prefix of the output file(s). Default sample1.
+
+*  -i INCLUDE_SAMPLES, --include-samples INCLUDE_SAMPLES
+
+Sample labels to include when the design matrix is given as a string (not a file). Comma-separated; must match labels in the count table.
+
+*  -b BETA_LABELS, --beta-labels BETA_LABELS
+
+Labels of the beta variables when the design matrix is given as a string. Comma-separated; the count must equal the number of design-matrix columns (including baseline). Default "beta_0,beta_1,...".
+
+*  --control-sgrna CONTROL_SGRNA / --control-gene CONTROL_GENE
+
+A list of control sgRNAs, or genes whose sgRNAs are used as controls, for normalization and null-distribution generation (mutually exclusive).
+
+### Optional arguments for CNV correction:
+
+*  --cnv-norm CNV_NORM
+
+A matrix of CNV data across cell lines, used to correct CNV-biased sgRNA scores before gene ranking.
+
+*  --cell-line CELL_LINE
+
+The cell line used for CNV normalization; must match a column name in `--cnv-norm`. Overrides the default of inferring cell-line names from the design-matrix columns.
+
+*  --cnv-est CNV_EST
+
+Estimate CNV profiles from the screening data. Requires a BED file of gene positions.
+
+### Optional arguments for the MLE module:
+
+*  --debug / --debug-gene DEBUG_GENE
+
+Output detailed running information, or run only a single gene by ID.
+
+*  --norm-method {none,median,total,control}
+
+Normalization method (see `test`). Default median.
+
+*  --genes-varmodeling GENES_VARMODELING
+
+Number of genes used for mean-variance modeling. Default 0.
+
+*  --permutation-round PERMUTATION_ROUND
+
+Rounds of permutation; total permutations = (#genes) × rounds. Suggested 10 (slower). Default 2.
+
+*  --no-permutation-by-group
+
+Permute all genes together instead of separately by sgRNA count. Faster, but p-values are accurate only when sgRNA-per-gene counts are similar.
+
+*  --max-sgrnapergene-permutation MAX_SGRNAPERGENE_PERMUTATION
+
+Skip beta-score / p-value computation for genes targeted by more than this many sgRNAs. Default 40.
+
+*  --remove-outliers
+
+Attempt to remove outliers (slower).
+
+*  --threads THREADS
+
+Number of threads. Default 1.
+
+*  --adjust-method {fdr,holm,pounds}
+
+sgRNA-level p-value adjustment method. Default fdr.
+
+### Optional arguments for the EM iteration:
+
+*  --sgrna-efficiency SGRNA_EFFICIENCY
+
+A file of sgRNA efficiency predictions, used as the initial guess of each sgRNA's efficiency. At least two columns: sgRNA ID and efficiency.
+
+*  --sgrna-eff-name-column SGRNA_EFF_NAME_COLUMN
+
+Column (0-based) of the sgRNA ID in the efficiency file. Default 0.
+
+*  --sgrna-eff-score-column SGRNA_EFF_SCORE_COLUMN
+
+Column (0-based) of the efficiency score in the efficiency file. Default 1.
+
+*  --update-efficiency
+
+Iteratively update sgRNA efficiency during EM iteration.
+
+### Optional arguments for Bayes estimation (experimental):
+
+*  --bayes
+
+Use the experimental Bayes module to estimate gene essentiality.
+
+*  -p, --PPI-prior
+
+Incorporate protein-protein interaction (PPI) information as a prior.
+
+*  -w PPI_WEIGHTING, --PPI-weighting PPI_WEIGHTING
+
+Weighting used to compute the PPI prior. If omitted, it is determined iteratively.
+
+*  -e NEGATIVE_CONTROL, --negative-control NEGATIVE_CONTROL
+
+Gene name of negative controls; the corresponding sgRNAs are viewed independently.
+
+
+## pathway
+
+Given a gene ranking from the `test` command, test whether gene sets / pathways
+(in GMT format) are enriched, using GSEA or RRA. Enrichment is evaluated in both
+the negative- and positive-selection directions unless `--single-ranking` is set.
+
+### usage:
+
+    mageck2 pathway [-h] --gene-ranking GENE_RANKING --gmt-file GMT_FILE
+                       [-n OUTPUT_PREFIX] [--method {gsea,rra}] [--single-ranking]
+                       [--sort-criteria {neg,pos}] [--keep-tmp]
+                       [--ranking-column RANKING_COLUMN]
+                       [--ranking-column-2 RANKING_COLUMN_2]
+                       [--pathway-alpha PATHWAY_ALPHA] [--permutation PERMUTATION]
+
+### Required arguments:
+
+*  --gene-ranking GENE_RANKING
+
+The `gene_summary` file (with both positive and negative selection tests) produced by the `test` command.
+
+*  --gmt-file GMT_FILE
+
+The pathway / gene-set file in GMT format.
+
+### Optional arguments:
+
+*  -n OUTPUT_PREFIX, --output-prefix OUTPUT_PREFIX
+
+Prefix of the output file(s). Default sample1.
+
+*  --method {gsea,rra}
+
+Enrichment method: GSEA (default) or RRA.
+
+*  --single-ranking
+
+Treat the input as a single-direction ranking (positive or negative); only one enrichment comparison is performed.
+
+*  --sort-criteria {neg,pos}
+
+Sort by negative (default) or positive selection.
+
+*  --ranking-column RANKING_COLUMN
+
+Column (integer index or label) in the gene summary used for ranking. Default "2" (the negative-selection RRA score).
+
+*  --ranking-column-2 RANKING_COLUMN_2
+
+Column for the opposite (positive-selection) direction. Default "8". Disabled with `--single-ranking`.
+
+*  --pathway-alpha PATHWAY_ALPHA
+
+Alpha value for RRA pathway enrichment. Default 0.25.
+
+*  --permutation PERMUTATION
+
+Number of permutations for GSEA. Default 1000.
+
+*  --keep-tmp
+
+Keep intermediate files.
+
+
+## plot
+
+Generate per-gene graphics (e.g. sgRNA read-count and rank plots) for selected
+genes from a count table and a `test` gene summary.
+
+### usage:
+
+    mageck2 plot [-h] -k COUNT_TABLE -g GENE_SUMMARY [--genes GENES] [-s SAMPLES]
+                    [-n OUTPUT_PREFIX] [--norm-method {none,median,total,control}]
+                    [--control-sgrna CONTROL_SGRNA | --control-gene CONTROL_GENE]
+                    [--keep-tmp]
+
+### Required arguments:
+
+*  -k COUNT_TABLE, --count-table COUNT_TABLE
+
+A tab-separated count table (sgRNA, gene, per-sample read counts).
+
+*  -g GENE_SUMMARY, --gene-summary GENE_SUMMARY
+
+The `gene_summary` file generated by the `test` command.
+
+### Optional arguments:
+
+*  --genes GENES
+
+Comma-separated list of genes to plot. Default: none.
+
+*  -s SAMPLES, --samples SAMPLES
+
+Comma-separated list of samples to plot. Default: all samples in the count table.
+
+*  -n OUTPUT_PREFIX, --output-prefix OUTPUT_PREFIX
+
+Prefix of the output file(s). Default sample1.
+
+*  --norm-method {none,median,total,control}
+
+Normalization method (see `test`). Default median.
+
+*  --control-sgrna CONTROL_SGRNA / --control-gene CONTROL_GENE
+
+Control sgRNAs, or genes whose sgRNAs are used as controls, for normalization (mutually exclusive).
+
+*  --keep-tmp
+
+Keep intermediate files.


### PR DESCRIPTION
Migrates the documentation that still lived only on the legacy [MAGeCK SourceForge wiki](https://sourceforge.net/p/mageck/wiki/Home/) into this repo, and removes the SourceForge backlinks. All content was checked against a fresh mageck2 install and the mageck2-demo scripts, not copied verbatim from the legacy (mageck / Python 2) wiki.

## Usage (`USAGE.md`)
Adds full reference sections for the four previously-undocumented subcommands — **`test`**, **`mle`**, **`pathway`**, **`plot`** — generated from the actual `mageck2 <sub> -h` output.

## File formats (`FILE_FORMATS.md`, new)
Documents every input (library, count table, design matrix, control lists, GMT, CNV, sgRNA efficiency) and output (`count`/`test`/`mle`/`pathway`/`plot`) file, with column tables from real demo outputs.

## Tutorials (`TUTORIAL.md`, new)
Seven step-by-step workflows grounded in the `mageck2-demo` `run.sh` commands: RRA from a count table, from raw fastq, MLE with a design matrix, CNV correction, control guides/genes, UMI counting, and paired-guide counting.

## FAQ (`FAQ.md`, new)
Curated from the legacy MAGeCK Q&A and updated for mageck2 (pip/Python 3, `mageck2` commands, R Markdown reports). Obsolete Python 2 / conda-conflict / PDF-only items dropped.

## README
Wires in all four pages (the "File formats" and "FAQ" sections were empty headers) and replaces the SourceForge backlinks.

### Deliberately not migrated
conda/Docker install (mageck2 has no such channels yet), the static-PDF visualization path (being retired for R Markdown), and legacy version history (superseded by the mageck2 CHANGELOG). The `pathway` page notes only the working `--method rra` output, since `--method gsea` is currently broken (davidliwei/mageck2#10).