### PR TITLE
Document multiple-baseline pooling in the MLE design matrix

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -176,6 +176,13 @@ Design-matrix rules:
   `0`/`1`.
 - At least one initial/reference sample (day 0 or plasmid) should have `1` only in
   the `baseline` column.
+- If more than one sample has `1` only in the `baseline` column (e.g. both
+  `HL60.initial` and `KBM7.initial` above), they are **pooled** into a single
+  shared reference — their average defines the baseline, and every beta is measured
+  against it. MAGeCK does not treat them as separate cell lines. This assumes the
+  initials share a common starting representation (here, the same library plasmid
+  pool). If your references genuinely differ, run `mle` separately for each so each
+  gets its own baseline.
 
 Run MLE:
 


### PR DESCRIPTION
Addresses the confusion in davidliwei/mageck2#23.

The MLE design-matrix rules in `TUTORIAL.md` describe the `baseline` column as "the shared reference state" but don't explain what happens when **more than one** sample is baseline-only (row sum 1) — which is exactly the two-cell-line demo (`HL60.initial` + `KBM7.initial`). A user reasonably asked whether MAGeCK distinguishes those two baselines by cell line.

It does not: baseline-only rows are **pooled** into a single averaged reference, and every beta is measured against it.

### What changed
- Added one design-matrix rule stating that multiple baseline-only samples are pooled into one shared (averaged) reference, that MAGeCK does not treat them as separate cell lines, that this assumes a common starting representation (same library plasmid pool), and that genuinely different references should be run separately.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)